### PR TITLE
Updated Slim\Views\TwigExtension

### DIFF
--- a/config/container.php
+++ b/config/container.php
@@ -39,8 +39,8 @@ $container['view'] = function ($container) {
         'debug' => true
     ]);
 
-    $basePath = rtrim(str_ireplace('index.php', '', $container['request']->getUri()->getBasePath()), '/');
-    $view->addExtension(new Slim\Views\TwigExtension($container['router'], $basePath));
+    $uri = \Slim\Http\Uri::createFromEnvironment(new \Slim\Http\Environment($_SERVER));
+    $view->addExtension(new Slim\Views\TwigExtension($container['router'], $uri));
     if (getenv('ENV') == 'dev') {
         $view->addExtension(new Twig_Extension_Profiler($container['twig_profile']));
         $view->addExtension(new Twig_Extension_Debug());


### PR DESCRIPTION
When using twig function is_current_path with a named route, I get :

Type: Error
Message: Call to a member function getBasePath() on string
File: /var/www/slim-sim/vendor/slim/twig-view/src/TwigExtension.php
Line: 93

The problem was in container.php


Hey!

Type: bug fix | new feature | code quality | documentation

Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SimonDevelop/slim-sim/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Thanks :smiley_cat:
